### PR TITLE
feat(docker-deploy): production Docker deploy pipeline

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,42 @@
+name: Deploy
+
+on:
+  push:
+    branches: [main]
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_BASE: ghcr.io/dlb-technologies-llc/powercycle
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Login to GitHub Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set image tag
+        run: echo "TAG=${GITHUB_SHA::7}" >> $GITHUB_ENV
+
+      - name: Build and push
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: Dockerfile
+          push: true
+          tags: |
+            ${{ env.IMAGE_BASE }}:latest
+            ${{ env.IMAGE_BASE }}:${{ env.TAG }}

--- a/Caddyfile
+++ b/Caddyfile
@@ -1,4 +1,6 @@
 :80 {
+    encode gzip
+
     handle /api/* {
         reverse_proxy localhost:3001
     }
@@ -14,7 +16,5 @@
 
         @dotfiles path /.*
         respond @dotfiles 404
-
-        encode gzip
     }
 }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,3 +1,9 @@
+x-logging: &default-logging
+  driver: json-file
+  options:
+    max-size: "10m"
+    max-file: "3"
+
 services:
   postgres:
     image: postgres:16-alpine
@@ -9,12 +15,16 @@ services:
       POSTGRES_DB: ${DB_NAME:-powercycle}
     volumes:
       - pgdata:/var/lib/postgresql/data
+    networks:
+      - internal
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U ${DB_USER:-powercycle} -d ${DB_NAME:-powercycle}"]
       interval: 10s
       timeout: 5s
       retries: 5
       start_period: 30s
+    mem_limit: 1g
+    logging: *default-logging
 
   app:
     build: .
@@ -34,12 +44,20 @@ services:
       postgres:
         condition: service_healthy
     restart: unless-stopped
+    networks:
+      - internal
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
       start_period: 10s
+    mem_limit: 512m
+    logging: *default-logging
 
 volumes:
   pgdata:
+
+networks:
+  internal:
+    driver: bridge

--- a/start.sh
+++ b/start.sh
@@ -6,8 +6,14 @@ cd /app/packages/backend
 bun run db:migrate || echo "Warning: migrations failed, continuing..."
 
 echo "Starting services..."
-set +e
+cleanup() { kill "$CADDY_PID" "$BACKEND_PID" 2>/dev/null; }
+trap cleanup EXIT
+
 caddy run --config /etc/caddy/Caddyfile &
+CADDY_PID=$!
+
 cd /app
 API_PORT=3001 bun run packages/backend/src/server.ts &
+BACKEND_PID=$!
+
 wait


### PR DESCRIPTION
## Summary

Set up production deployment pipeline for powercycle. Adds GitHub Actions deploy workflow (build + push to GHCR), fixes local Docker config for parity with production patterns from spotify-pomodoro and eds-connective.

## Completed Tasks

- [x] deploy-workflow: GitHub Actions workflow to build and push Docker image to GHCR
- [x] fix-startup-files: Fix start.sh cleanup trap and Caddyfile gzip placement
- [x] align-local-compose: Align docker-compose.yml with srv conventions (logging, mem_limit, networks)
- [x] verify-docker-build: Docker image builds and passes health check
- [x] review-and-changeset: All verification passes

## Test Plan

- [ ] Docker image builds successfully (`docker build -t powercycle:test .`)
- [ ] Health check passes (`/api/health` returns 200)
- [ ] Frontend serves on `/`
- [ ] API proxies through `/api/*`
- [ ] Deploy workflow triggers on push to main only
- [ ] Pushes both `:latest` and `:${SHA::7}` tags to GHCR
- [ ] start.sh has cleanup trap with named PIDs
- [ ] Caddyfile has `encode gzip` at site-block level
- [ ] Logging anchor applied to both services
- [ ] Memory limits set (512m app, 1g postgres)
- [ ] Network isolation: postgres on internal only

---
*Generated by `/execute` from plan: `~/c0de/plans/powercycle/docker-deploy.md`*