### PR TITLE
feat(docker-compose-fixes): healthcheck start_period + web network

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -46,12 +46,13 @@ services:
     restart: unless-stopped
     networks:
       - internal
+      - web
     healthcheck:
       test: ["CMD", "curl", "-f", "http://localhost:80/api/health"]
       interval: 30s
       timeout: 10s
       retries: 3
-      start_period: 10s
+      start_period: 30s
     mem_limit: 512m
     logging: *default-logging
 
@@ -61,3 +62,5 @@ volumes:
 networks:
   internal:
     driver: bridge
+  web:
+    external: true


### PR DESCRIPTION
## Summary

- Increase app healthcheck `start_period` from 10s to 30s to avoid premature unhealthy status during DB migrations (Closes #19)
- Add external `web` network to app service so Caddy reverse proxy can route traffic (Closes #20)

## Test Plan

- [ ] `start_period` is `30s` for the app healthcheck
- [ ] App service is on both `internal` and `web` networks
- [ ] `web` network is declared as `external: true`
- [ ] YAML is valid (no syntax errors)
- [ ] `docker compose config` parses without errors

---
*Generated by `/execute` from plan: `~/c0de/plans/powercycle/docker-compose-fixes.md`*