### PR TITLE
fix(resume): fetch API preferences during workout resume

### DIFF
--- a/packages/frontend/src/components/WorkoutIsland.tsx
+++ b/packages/frontend/src/components/WorkoutIsland.tsx
@@ -129,14 +129,26 @@ export default function WorkoutIsland({ workoutId }: WorkoutIslandProps) {
 	useEffect(() => {
 		if (!id || !plan || resumeChecked) return;
 
-		fetch(`/api/workouts/${id}/sets`)
-			.then((res) => {
+		Promise.all([
+			fetch(`/api/workouts/${id}/sets`).then((res) => {
 				if (!res.ok) throw new Error("Failed to fetch sets");
-				return res.json();
-			})
-			.then((sets: unknown[]) => {
+				return res.json() as Promise<unknown[]>;
+			}),
+			fetch("/api/preferences/exercises")
+				.then((res) => {
+					if (!res.ok) return [];
+					return res.json() as Promise<
+						Array<{ slotKey: string; exerciseName: string }>
+					>;
+				})
+				.catch(() => [] as Array<{ slotKey: string; exerciseName: string }>),
+		])
+			.then(([sets, prefs]) => {
 				if (sets.length > 0) {
 					const selections = buildSelectionsFromLocalStorage(plan);
+					for (const p of prefs) {
+						selections[p.slotKey] = p.exerciseName;
+					}
 					flow.initializeAt(sets.length, selections);
 				}
 				setResumeChecked(true);


### PR DESCRIPTION
## Summary

Resume was reading exercise preferences from localStorage only, missing changes made on other devices. Now fetches both sets and preferences in parallel via `Promise.all`, with API preferences overriding localStorage.

Closes #42

## Changes

One file: `packages/frontend/src/components/WorkoutIsland.tsx`

- Resume `useEffect` now does `Promise.all([fetchSets, fetchPreferences])`
- API preferences override localStorage selections (API is source of truth)
- Preferences fetch failure silently falls back to localStorage (graceful degradation)

## Test Plan

- [ ] Resume with API preferences: change exercise on device A, resume workout on device B → uses device A's selection
- [ ] Resume with API down: preferences fetch fails → falls back to localStorage
- [ ] Fresh workout (no completed sets) → still shows overview as normal