### PR TITLE
fix(frontend): replace window.location.reload() with atom invalidation

### DIFF
--- a/packages/frontend/src/components/WeightManagement.tsx
+++ b/packages/frontend/src/components/WeightManagement.tsx
@@ -1,8 +1,8 @@
-import { useAtomSet, useAtomValue } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet, useAtomValue } from "@effect/atom-react";
 import { Exit } from "effect";
 import { AsyncResult } from "effect/unstable/reactivity";
 import { useState } from "react";
-import { update1rmAtom } from "../atoms/cycles";
+import { currentCycleAtom, update1rmAtom } from "../atoms/cycles";
 import {
 	deleteExerciseWeightAtom,
 	exerciseWeightsAtom,
@@ -59,6 +59,7 @@ export default function WeightManagement({ cycle }: WeightManagementProps) {
 
 function OneRmSection({ cycle }: { cycle: WeightManagementProps["cycle"] }) {
 	const update1rm = useAtomSet(update1rmAtom, { mode: "promiseExit" });
+	const refreshCycle = useAtomRefresh(currentCycleAtom);
 	const [editingLift, setEditingLift] = useState<string | null>(null);
 	const [editValue, setEditValue] = useState("");
 	const [isSaving, setIsSaving] = useState(false);
@@ -85,7 +86,9 @@ function OneRmSection({ cycle }: { cycle: WeightManagementProps["cycle"] }) {
 				setIsSaving(false);
 			},
 			onSuccess: () => {
-				window.location.reload();
+				refreshCycle();
+				setEditingLift(null);
+				setIsSaving(false);
 			},
 		});
 	};
@@ -155,6 +158,7 @@ function OneRmSection({ cycle }: { cycle: WeightManagementProps["cycle"] }) {
 
 function SavedWeightsSection() {
 	const result = useAtomValue(exerciseWeightsAtom);
+	const refreshWeights = useAtomRefresh(exerciseWeightsAtom);
 	const deleteWeight = useAtomSet(deleteExerciseWeightAtom, {
 		mode: "promiseExit",
 	});
@@ -171,7 +175,8 @@ function SavedWeightsSection() {
 				setDeletingName(null);
 			},
 			onSuccess: () => {
-				window.location.reload();
+				refreshWeights();
+				setDeletingName(null);
 			},
 		});
 	};

--- a/packages/frontend/src/components/WorkoutOverview.tsx
+++ b/packages/frontend/src/components/WorkoutOverview.tsx
@@ -1,8 +1,9 @@
-import { useAtomSet } from "@effect/atom-react";
+import { useAtomRefresh, useAtomSet } from "@effect/atom-react";
 import { EXERCISE_OPTIONS } from "@powercycle/shared/schema/workout";
 import { Exit } from "effect";
 import { useEffect, useState } from "react";
 import { update1rmAtom } from "../atoms/cycles";
+import { nextWorkoutAtom } from "../atoms/workouts";
 
 const LIFT_DISPLAY_NAMES: Record<string, string> = {
 	squat: "Squat",
@@ -123,6 +124,7 @@ export function WorkoutOverview({ plan, unit, onStart }: WorkoutOverviewProps) {
 	const [oneRmError, setOneRmError] = useState("");
 	const [isSubmitting1rm, setIsSubmitting1rm] = useState(false);
 	const update1rm = useAtomSet(update1rmAtom, { mode: "promiseExit" });
+	const refreshWorkout = useAtomRefresh(nextWorkoutAtom);
 
 	const handleSubmit1rm = async () => {
 		const value = Number(oneRmInput);
@@ -144,7 +146,9 @@ export function WorkoutOverview({ plan, unit, onStart }: WorkoutOverviewProps) {
 				setIsSubmitting1rm(false);
 			},
 			onSuccess: () => {
-				window.location.reload();
+				refreshWorkout();
+				setOneRmInput("");
+				setIsSubmitting1rm(false);
 			},
 		});
 	};


### PR DESCRIPTION
## Summary

Replaces 3 `window.location.reload()` calls with `useAtomRefresh` from `@effect/atom-react`, eliminating full page reload flashes and scroll position loss after mutations.

- **WeightManagement.tsx**: refresh `currentCycleAtom` after 1RM update, refresh `exerciseWeightsAtom` after weight delete
- **WorkoutOverview.tsx**: refresh `nextWorkoutAtom` after inline 1RM save

Closes #45

## Test Plan

- [ ] Edit a 1RM in Weight Management → data updates without page flash
- [ ] Delete a saved weight → list updates without page flash
- [ ] Save inline 1RM on workout overview → sets recalculate without page flash
- [ ] Scroll position preserved after all three mutations