### PR TITLE
feat: narrow CycleResponse literals + extract DeepMutable (#66 #67)

### DIFF
--- a/packages/frontend/src/components/DashboardIsland.tsx
+++ b/packages/frontend/src/components/DashboardIsland.tsx
@@ -91,8 +91,8 @@ export default function DashboardIsland() {
 		const exit = await startWorkout({
 			payload: {
 				cycleId: cycle.id,
-				round: cycle.currentRound as 1 | 2 | 3 | 4,
-				day: cycle.currentDay as 1 | 2 | 3 | 4,
+				round: cycle.currentRound,
+				day: cycle.currentDay,
 			},
 		});
 		Exit.match(exit, {

--- a/packages/frontend/src/components/ProgressionIsland.tsx
+++ b/packages/frontend/src/components/ProgressionIsland.tsx
@@ -95,7 +95,7 @@ export default function ProgressionIsland() {
 				bench: progression.bench?.newMax ?? null,
 				deadlift: progression.deadlift?.newMax ?? null,
 				ohp: progression.ohp?.newMax ?? null,
-				unit: (cycle.unit || "lbs") as "lbs" | "kg",
+				unit: cycle.unit,
 			},
 		});
 		Exit.match(exit, {

--- a/packages/frontend/src/components/WorkoutIsland.tsx
+++ b/packages/frontend/src/components/WorkoutIsland.tsx
@@ -12,15 +12,10 @@ import {
 import type { FlatSet } from "../hooks/useWorkoutFlow";
 import { useWorkoutFlow } from "../hooks/useWorkoutFlow";
 import { useWorkoutTimer } from "../hooks/useWorkoutTimer";
+import type { DeepMutable } from "../lib/types";
 import { ActiveSetView } from "./ActiveSetView";
 import { WorkoutOverview } from "./WorkoutOverview";
 
-type DeepMutable<T> =
-	T extends ReadonlyArray<infer U>
-		? Array<DeepMutable<U>>
-		: T extends object
-			? { -readonly [K in keyof T]: DeepMutable<T[K]> }
-			: T;
 type WorkoutPlanData = DeepMutable<typeof WorkoutPlanResponse.Type>;
 
 interface WorkoutIslandProps {

--- a/packages/frontend/src/lib/types.ts
+++ b/packages/frontend/src/lib/types.ts
@@ -1,0 +1,11 @@
+/**
+ * Recursively strips `readonly` modifiers from Effect Schema types.
+ * Effect schemas produce readonly arrays/objects; React components
+ * often need mutable versions for state patterns.
+ */
+export type DeepMutable<T> =
+	T extends ReadonlyArray<infer U>
+		? Array<DeepMutable<U>>
+		: T extends object
+			? { -readonly [K in keyof T]: DeepMutable<T[K]> }
+			: T;

--- a/packages/shared/src/schema/api.ts
+++ b/packages/shared/src/schema/api.ts
@@ -21,11 +21,6 @@ export const CycleResponse = Schema.Struct({
 	// Date → String for JSON serialization
 	startedAt: Schema.String,
 	completedAt: Schema.NullOr(Schema.String),
-	// Literal → Number for JSON serialization
-	currentRound: Schema.Number,
-	currentDay: Schema.Number,
-	// Literal → String for JSON serialization
-	unit: Schema.String,
 });
 
 export const NullableCycleResponse = Schema.NullOr(CycleResponse);

--- a/packages/shared/src/schema/entities/cycle.ts
+++ b/packages/shared/src/schema/entities/cycle.ts
@@ -58,8 +58,8 @@ export class Cycle extends Schema.Class<Cycle>("Cycle")({
 			deadlift1rm: cycle.deadlift1rm,
 			ohp1rm: cycle.ohp1rm,
 			unit: cycle.unit,
-			currentRound: cycle.currentRound as number,
-			currentDay: cycle.currentDay as number,
+			currentRound: cycle.currentRound,
+			currentDay: cycle.currentDay,
 			startedAt: cycle.startedAt.toISOString(),
 			completedAt: cycle.completedAt?.toISOString() ?? null,
 		};


### PR DESCRIPTION
## Summary

Two type-safety improvements from postmortem #65:
- **Narrow CycleResponse** (#66): Remove `Schema.Number`/`Schema.String` overrides, letting `Round`/`TrainingDay`/`Unit` literal types flow from `Cycle.fields`. Removes `as` casts in entity `toResponse()` and frontend consumers.
- **Extract DeepMutable** (#67): Move `DeepMutable<T>` utility from `WorkoutIsland.tsx` to `packages/frontend/src/lib/types.ts` for reuse.

## Completed Tasks

- [x] narrow-cycle-response: Narrow CycleResponse schema fields to literal types
- [x] extract-deep-mutable: Extract DeepMutable<T> to shared frontend utility types

## Test Plan

- [ ] `CycleResponse.Type` has `currentRound: 1|2|3|4`, `currentDay: 1|2|3|4`, `unit: "lbs"|"kg"`
- [ ] Zero `as` casts for round/day/unit in frontend components
- [ ] Zero `as number` casts in `Cycle.toResponse()`
- [ ] `DeepMutable` exported from `packages/frontend/src/lib/types.ts`
- [ ] `WorkoutIsland.tsx` imports `DeepMutable` from `../lib/types`
- [ ] All 144 unit tests pass
- [ ] Typecheck passes with 0 errors

Closes #66, Closes #67

---
*Generated by `/execute` from plan: `~/c0de/plans/powercycle/issues-66-67.md`*