### PR TITLE
fix(test): handle -0 coercion in Cycle.decodeRow test

### DIFF
--- a/packages/shared/test/entities/cycle.test.ts
+++ b/packages/shared/test/entities/cycle.test.ts
@@ -88,12 +88,16 @@ describe("Cycle.decodeRow", () => {
 				ohp1rm: base.ohp1rm != null ? String(base.ohp1rm) : null,
 			};
 
+			// String(-0) → "0" → Number("0") → +0, so the roundtrip normalizes -0
+			const normalize = (v: number | null) =>
+				v != null ? Number(String(v)) : null;
+
 			const cycle = yield* Cycle.decodeRow(drizzleRow);
 			expect(cycle).toBeInstanceOf(Cycle);
-			expect(cycle.squat1rm).toBe(base.squat1rm);
-			expect(cycle.bench1rm).toBe(base.bench1rm);
-			expect(cycle.deadlift1rm).toBe(base.deadlift1rm);
-			expect(cycle.ohp1rm).toBe(base.ohp1rm);
+			expect(cycle.squat1rm).toBe(normalize(base.squat1rm));
+			expect(cycle.bench1rm).toBe(normalize(base.bench1rm));
+			expect(cycle.deadlift1rm).toBe(normalize(base.deadlift1rm));
+			expect(cycle.ohp1rm).toBe(normalize(base.ohp1rm));
 			expect(cycle.unit).toBe(base.unit);
 		}),
 	);


### PR DESCRIPTION
## Summary

- Fix flaky `Cycle.decodeRow > decodes Drizzle row with string numerics` test
- `String(-0)` → `"0"` → `Number("0")` → `+0`, so the string roundtrip through `DrizzleRow` normalizes `-0` to `+0`
- `toBe` uses `Object.is` which distinguishes `-0` from `+0`, causing intermittent failures when the arbitrary generates `-0`
- Fix: normalize expected values through the same `String→Number` roundtrip

## Test Plan

- [ ] CI passes consistently (the test was flaky — `-0` is only generated occasionally by the arbitrary)