### PR TITLE
fix: focus ring visibility + ExerciseWeight decode test (#101, #87)

### DIFF
--- a/packages/frontend/src/styles/global.css
+++ b/packages/frontend/src/styles/global.css
@@ -60,7 +60,7 @@
 	--destructive: #dc2626;
 	--border: #e5e7eb;
 	--input: #d1d5db;
-	--ring: #0a0a0a;
+	--ring: #2563eb;
 	--chart-1: #0a0a0a;
 	--chart-2: #4b5563;
 	--chart-3: #6b7280;

--- a/packages/shared/test/entities/exercise-weight.test.ts
+++ b/packages/shared/test/entities/exercise-weight.test.ts
@@ -37,6 +37,10 @@ describe("ExerciseWeight entity", () => {
 });
 
 describe("ExerciseWeight.decodeRow", () => {
+	// String(-0) → "0" → Number("0") → +0, so the roundtrip normalizes -0
+	const normalize = (v: number | null) =>
+		v != null ? Number(String(v)) : null;
+
 	it.effect("decodes Drizzle row with string weight and rpe", () =>
 		Effect.gen(function* () {
 			const base = sample();
@@ -48,8 +52,8 @@ describe("ExerciseWeight.decodeRow", () => {
 
 			const ew = yield* ExerciseWeight.decodeRow(drizzleRow);
 			expect(ew).toBeInstanceOf(ExerciseWeight);
-			expect(ew.weight).toBe(base.weight);
-			expect(ew.rpe).toBe(base.rpe);
+			expect(ew.weight).toBe(normalize(base.weight));
+			expect(ew.rpe).toBe(normalize(base.rpe));
 		}),
 	);
 
@@ -64,7 +68,7 @@ describe("ExerciseWeight.decodeRow", () => {
 
 			const ew = yield* ExerciseWeight.decodeRow(drizzleRow);
 			expect(ew).toBeInstanceOf(ExerciseWeight);
-			expect(ew.weight).toBe(base.weight);
+			expect(ew.weight).toBe(normalize(base.weight));
 			expect(ew.rpe).toBeNull();
 			expect(ew.unit).toBe(base.unit);
 		}),


### PR DESCRIPTION
## Summary

- **#101**: Change `--ring` CSS variable from `#0a0a0a` (near-black) to `#2563eb` (blue-600) for clearly visible focus rings on white backgrounds
- **#87**: Apply `-0/+0` normalize pattern to ExerciseWeight.decodeRow test (last remaining entity without it)
- **#102**: Already resolved by PR #94/#106 — CLAUDE.md already has skip-sets documentation

Closes #101
Closes #87
Closes #102

## Test Plan

- [ ] Focus ring on `<Input>` elements is clearly visible (blue ring on white background)
- [ ] Focus ring on `<select>` elements in WorkoutOverview is clearly visible
- [ ] ExerciseWeight.decodeRow test passes with property-generated data (144/144 tests pass)
- [ ] No visual regressions on other shadcn components using `ring-ring/50`