### PR TITLE
feat: auto-populate maxes from previous cycle (#119)

### DIFF
--- a/packages/backend/src/api/cycles.ts
+++ b/packages/backend/src/api/cycles.ts
@@ -1,12 +1,14 @@
 import { calculateCycleProgression } from "@powercycle/shared";
 import { NotFoundError } from "@powercycle/shared/errors/index";
 import { Cycle } from "@powercycle/shared/schema/entities/cycle";
+import type { Unit } from "@powercycle/shared/schema/lifts";
 import { Effect } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { DEFAULT_USER_ID } from "../lib/constants.js";
 import {
 	countCyclesByUserId,
 	findActiveCycle,
+	findLatestCompletedCycleMaxes,
 	insertCycle,
 	updateCycle,
 } from "../lib/queries.js";
@@ -73,6 +75,20 @@ export const CyclesLive = HttpApiBuilder.group(
 					return calculateCycleProgression(ctx.payload, currentLifts);
 				}),
 			)
+			.handle("previousMaxes", (_ctx) =>
+				Effect.gen(function* () {
+					const userId = DEFAULT_USER_ID;
+					const row = yield* findLatestCompletedCycleMaxes(db, userId);
+					if (!row) return null;
+					return {
+						squat: row.squat1rm != null ? Number(row.squat1rm) : null,
+						bench: row.bench1rm != null ? Number(row.bench1rm) : null,
+						deadlift: row.deadlift1rm != null ? Number(row.deadlift1rm) : null,
+						ohp: row.ohp1rm != null ? Number(row.ohp1rm) : null,
+						unit: row.unit === "kg" ? "kg" : "lbs" satisfies Unit,
+					};
+				}),
+			)
 			.handle("next", (ctx) =>
 				Effect.gen(function* () {
 					const userId = DEFAULT_USER_ID;
@@ -82,14 +98,32 @@ export const CyclesLive = HttpApiBuilder.group(
 							completedAt: new Date(),
 						});
 					}
+					// Fall back to previous cycle maxes for any null lifts
+					const previousRow = yield* findLatestCompletedCycleMaxes(db, userId);
 					const cycleCount = yield* countCyclesByUserId(db, userId);
 					const entity = yield* cycleService.createEntity(
 						userId,
 						{
-							squat: ctx.payload.squat,
-							bench: ctx.payload.bench,
-							deadlift: ctx.payload.deadlift,
-							ohp: ctx.payload.ohp,
+							squat:
+								ctx.payload.squat ??
+								(previousRow?.squat1rm != null
+									? Number(previousRow.squat1rm)
+									: null),
+							bench:
+								ctx.payload.bench ??
+								(previousRow?.bench1rm != null
+									? Number(previousRow.bench1rm)
+									: null),
+							deadlift:
+								ctx.payload.deadlift ??
+								(previousRow?.deadlift1rm != null
+									? Number(previousRow.deadlift1rm)
+									: null),
+							ohp:
+								ctx.payload.ohp ??
+								(previousRow?.ohp1rm != null
+									? Number(previousRow.ohp1rm)
+									: null),
 							unit: ctx.payload.unit,
 						},
 						cycleCount + 1,

--- a/packages/backend/src/api/cycles.ts
+++ b/packages/backend/src/api/cycles.ts
@@ -27,7 +27,7 @@ const decodeMaxesRow = (row: {
 	bench: row.bench1rm != null ? Number(row.bench1rm) : null,
 	deadlift: row.deadlift1rm != null ? Number(row.deadlift1rm) : null,
 	ohp: row.ohp1rm != null ? Number(row.ohp1rm) : null,
-	unit: Schema.decodeSync(Unit)(row.unit),
+	unit: Schema.decodeUnknownSync(Unit)(row.unit),
 });
 
 export const CyclesLive = HttpApiBuilder.group(

--- a/packages/backend/src/api/cycles.ts
+++ b/packages/backend/src/api/cycles.ts
@@ -1,8 +1,8 @@
 import { calculateCycleProgression } from "@powercycle/shared";
 import { NotFoundError } from "@powercycle/shared/errors/index";
 import { Cycle } from "@powercycle/shared/schema/entities/cycle";
-import type { Unit } from "@powercycle/shared/schema/lifts";
-import { Effect } from "effect";
+import { Unit } from "@powercycle/shared/schema/lifts";
+import { Effect, Schema } from "effect";
 import { HttpApiBuilder } from "effect/unstable/httpapi";
 import { DEFAULT_USER_ID } from "../lib/constants.js";
 import {
@@ -15,6 +15,20 @@ import {
 import { CycleService } from "../services/CycleService.js";
 import { DatabaseService } from "../services/DatabaseService.js";
 import { PowerCycleApi } from "./index.js";
+
+const decodeMaxesRow = (row: {
+	squat1rm: string | null;
+	bench1rm: string | null;
+	deadlift1rm: string | null;
+	ohp1rm: string | null;
+	unit: string;
+}) => ({
+	squat: row.squat1rm != null ? Number(row.squat1rm) : null,
+	bench: row.bench1rm != null ? Number(row.bench1rm) : null,
+	deadlift: row.deadlift1rm != null ? Number(row.deadlift1rm) : null,
+	ohp: row.ohp1rm != null ? Number(row.ohp1rm) : null,
+	unit: Schema.decodeSync(Unit)(row.unit),
+});
 
 export const CyclesLive = HttpApiBuilder.group(
 	PowerCycleApi,
@@ -80,13 +94,7 @@ export const CyclesLive = HttpApiBuilder.group(
 					const userId = DEFAULT_USER_ID;
 					const row = yield* findLatestCompletedCycleMaxes(db, userId);
 					if (!row) return null;
-					return {
-						squat: row.squat1rm != null ? Number(row.squat1rm) : null,
-						bench: row.bench1rm != null ? Number(row.bench1rm) : null,
-						deadlift: row.deadlift1rm != null ? Number(row.deadlift1rm) : null,
-						ohp: row.ohp1rm != null ? Number(row.ohp1rm) : null,
-						unit: row.unit === "kg" ? "kg" : "lbs" satisfies Unit,
-					};
+					return decodeMaxesRow(row);
 				}),
 			)
 			.handle("next", (ctx) =>
@@ -98,32 +106,17 @@ export const CyclesLive = HttpApiBuilder.group(
 							completedAt: new Date(),
 						});
 					}
-					// Fall back to previous cycle maxes for any null lifts
+					// Fall back to most recently completed cycle's maxes for any null lifts
 					const previousRow = yield* findLatestCompletedCycleMaxes(db, userId);
+					const previous = previousRow ? decodeMaxesRow(previousRow) : null;
 					const cycleCount = yield* countCyclesByUserId(db, userId);
 					const entity = yield* cycleService.createEntity(
 						userId,
 						{
-							squat:
-								ctx.payload.squat ??
-								(previousRow?.squat1rm != null
-									? Number(previousRow.squat1rm)
-									: null),
-							bench:
-								ctx.payload.bench ??
-								(previousRow?.bench1rm != null
-									? Number(previousRow.bench1rm)
-									: null),
-							deadlift:
-								ctx.payload.deadlift ??
-								(previousRow?.deadlift1rm != null
-									? Number(previousRow.deadlift1rm)
-									: null),
-							ohp:
-								ctx.payload.ohp ??
-								(previousRow?.ohp1rm != null
-									? Number(previousRow.ohp1rm)
-									: null),
+							squat: ctx.payload.squat ?? previous?.squat ?? null,
+							bench: ctx.payload.bench ?? previous?.bench ?? null,
+							deadlift: ctx.payload.deadlift ?? previous?.deadlift ?? null,
+							ohp: ctx.payload.ohp ?? previous?.ohp ?? null,
 							unit: ctx.payload.unit,
 						},
 						cycleCount + 1,

--- a/packages/backend/src/lib/queries.ts
+++ b/packages/backend/src/lib/queries.ts
@@ -272,6 +272,28 @@ export const deleteExerciseWeight = Effect.fn("queries.deleteExerciseWeight")(
 	},
 );
 
+export const findLatestCompletedCycleMaxes = Effect.fn(
+	"queries.findLatestCompletedCycleMaxes",
+)(function* (db: Database, userId: string) {
+	const rows = yield* Effect.tryPromise({
+		try: () =>
+			db
+				.select({
+					squat1rm: cycles.squat1rm,
+					bench1rm: cycles.bench1rm,
+					deadlift1rm: cycles.deadlift1rm,
+					ohp1rm: cycles.ohp1rm,
+					unit: cycles.unit,
+				})
+				.from(cycles)
+				.where(and(eq(cycles.userId, userId), isNotNull(cycles.completedAt)))
+				.orderBy(desc(cycles.completedAt))
+				.limit(1),
+		catch: (error) => new InternalError({ message: `Query failed: ${error}` }),
+	});
+	return rows[0] ?? null;
+});
+
 export const findLastSessionSets = Effect.fn("queries.findLastSessionSets")(
 	function* (db: Database, userId: string) {
 		return yield* Effect.tryPromise({

--- a/packages/backend/test/services/cycle-service.test.ts
+++ b/packages/backend/test/services/cycle-service.test.ts
@@ -1,4 +1,5 @@
-import { expect, layer } from "@effect/vitest";
+import { describe, expect, it, layer } from "@effect/vitest";
+import { calculateProgression } from "@powercycle/shared/engine/progression";
 import { Cycle } from "@powercycle/shared/schema/entities/cycle";
 import { UserLifts } from "@powercycle/shared/schema/lifts";
 import { Round, TrainingDay } from "@powercycle/shared/schema/program";
@@ -259,6 +260,41 @@ layer(CycleLive)("CycleService", (it) => {
 		}),
 	);
 
+	it.effect("createEntity with fallback maxes preserves provided values", () =>
+		Effect.gen(function* () {
+			const service = yield* CycleService;
+			// Simulate: user provided squat/deadlift, handler fell back to previous for bench/ohp
+			const lifts = {
+				...sampleLifts(),
+				bench: 225, // "from previous cycle"
+				ohp: 135, // "from previous cycle"
+			};
+			const cycle = yield* service.createEntity(crypto.randomUUID(), lifts, 2);
+			expect(cycle.bench1rm).toBe(225);
+			expect(cycle.ohp1rm).toBe(135);
+			expect(cycle.cycleNumber).toBe(2);
+		}),
+	);
+
+	it.effect(
+		"createEntity stores null when no value provided and no fallback",
+		() =>
+			Effect.gen(function* () {
+				const service = yield* CycleService;
+				const lifts = sampleLiftsWithNulls(); // bench and ohp are null
+				const cycle = yield* service.createEntity(
+					crypto.randomUUID(),
+					lifts,
+					2,
+				);
+				expect(cycle.bench1rm).toBeNull();
+				expect(cycle.ohp1rm).toBeNull();
+				// squat and deadlift should still have values
+				expect(cycle.squat1rm).toBe(lifts.squat);
+				expect(cycle.deadlift1rm).toBe(lifts.deadlift);
+			}),
+	);
+
 	it.effect.prop(
 		"createEntity always starts at round 1, day 1",
 		{
@@ -283,4 +319,20 @@ layer(CycleLive)("CycleService", (it) => {
 				expect(cycle.completedAt).toBeNull();
 			}),
 	);
+});
+
+describe("progression invariants", () => {
+	it("never decreases maxes", () => {
+		const result = calculateProgression(200, 5, 250);
+		// Even though calculated 1RM from 200x5 < 250, newMax should be >= currentMax
+		expect(result.newMax).toBeGreaterThanOrEqual(result.currentMax);
+		expect(result.progressed).toBe(false);
+	});
+
+	it("increases max when AMRAP result exceeds current", () => {
+		const result = calculateProgression(300, 5, 315);
+		// 300 * (1 + 5/30) = 350, which > 315
+		expect(result.newMax).toBeGreaterThan(result.currentMax);
+		expect(result.progressed).toBe(true);
+	});
 });

--- a/packages/backend/test/services/cycle-service.test.ts
+++ b/packages/backend/test/services/cycle-service.test.ts
@@ -1,5 +1,4 @@
-import { describe, expect, it, layer } from "@effect/vitest";
-import { calculateProgression } from "@powercycle/shared/engine/progression";
+import { expect, layer } from "@effect/vitest";
 import { Cycle } from "@powercycle/shared/schema/entities/cycle";
 import { UserLifts } from "@powercycle/shared/schema/lifts";
 import { Round, TrainingDay } from "@powercycle/shared/schema/program";
@@ -260,14 +259,13 @@ layer(CycleLive)("CycleService", (it) => {
 		}),
 	);
 
-	it.effect("createEntity with fallback maxes preserves provided values", () =>
+	it.effect("createEntity stores mixed number and null lifts faithfully", () =>
 		Effect.gen(function* () {
 			const service = yield* CycleService;
-			// Simulate: user provided squat/deadlift, handler fell back to previous for bench/ohp
 			const lifts = {
 				...sampleLifts(),
-				bench: 225, // "from previous cycle"
-				ohp: 135, // "from previous cycle"
+				bench: 225,
+				ohp: 135,
 			};
 			const cycle = yield* service.createEntity(crypto.randomUUID(), lifts, 2);
 			expect(cycle.bench1rm).toBe(225);
@@ -319,20 +317,4 @@ layer(CycleLive)("CycleService", (it) => {
 				expect(cycle.completedAt).toBeNull();
 			}),
 	);
-});
-
-describe("progression invariants", () => {
-	it("never decreases maxes", () => {
-		const result = calculateProgression(200, 5, 250);
-		// Even though calculated 1RM from 200x5 < 250, newMax should be >= currentMax
-		expect(result.newMax).toBeGreaterThanOrEqual(result.currentMax);
-		expect(result.progressed).toBe(false);
-	});
-
-	it("increases max when AMRAP result exceeds current", () => {
-		const result = calculateProgression(300, 5, 315);
-		// 300 * (1 + 5/30) = 350, which > 315
-		expect(result.newMax).toBeGreaterThan(result.currentMax);
-		expect(result.progressed).toBe(true);
-	});
 });

--- a/packages/frontend/src/atoms/cycles.ts
+++ b/packages/frontend/src/atoms/cycles.ts
@@ -8,6 +8,12 @@ import { ApiClient } from "./client";
  */
 export const currentCycleAtom = ApiClient.query("cycles", "current", {});
 
+/**
+ * Query atom for the previous cycle's maxes (for pre-filling new cycle setup).
+ * Returns null if no completed cycles exist.
+ */
+export const previousMaxesAtom = ApiClient.query("cycles", "previousMaxes", {});
+
 // ── Mutation Atoms ──
 
 /**

--- a/packages/frontend/src/components/SetupIsland.tsx
+++ b/packages/frontend/src/components/SetupIsland.tsx
@@ -1,12 +1,13 @@
-import { useAtomSet } from "@effect/atom-react";
+import { useAtomSet, useAtomValue } from "@effect/atom-react";
 import { Exit } from "effect";
-import { useState } from "react";
+import { AsyncResult } from "effect/unstable/reactivity";
+import { useEffect, useState } from "react";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent } from "@/components/ui/card";
 import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { cn } from "@/lib/utils";
-import { createCycleAtom } from "../atoms/cycles";
+import { createCycleAtom, previousMaxesAtom } from "../atoms/cycles";
 
 const lifts = [
 	{ label: "Squat" },
@@ -23,6 +24,22 @@ export default function SetupIsland() {
 	const [unit, setUnit] = useState<"lbs" | "kg">("lbs");
 	const [error, setError] = useState("");
 	const [isPending, setIsPending] = useState(false);
+
+	const previousMaxesResult = useAtomValue(previousMaxesAtom);
+	const [prefilled, setPrefilled] = useState(false);
+
+	useEffect(() => {
+		if (prefilled) return;
+		if (!AsyncResult.isSuccess(previousMaxesResult)) return;
+		const data = previousMaxesResult.value;
+		if (!data) return; // null = no previous cycles (first-time user)
+		setPrefilled(true);
+		if (data.squat != null) setSquat(String(data.squat));
+		if (data.bench != null) setBench(String(data.bench));
+		if (data.deadlift != null) setDeadlift(String(data.deadlift));
+		if (data.ohp != null) setOhp(String(data.ohp));
+		setUnit(data.unit);
+	}, [previousMaxesResult, prefilled]);
 
 	const createCycle = useAtomSet(createCycleAtom, { mode: "promiseExit" });
 
@@ -75,6 +92,11 @@ export default function SetupIsland() {
 			<p className="text-sm text-muted-foreground mb-8">
 				Enter any 1RMs you know — you'll be asked for others when needed.
 			</p>
+			{prefilled && (
+				<p className="text-xs text-muted-foreground mb-4">
+					Pre-filled from your last cycle. Edit any value to update.
+				</p>
+			)}
 			<form onSubmit={handleSubmit} className="space-y-3">
 				<div className="inline-flex rounded-lg border border-border p-1 mb-4">
 					<Button

--- a/packages/shared/src/api/Api.ts
+++ b/packages/shared/src/api/Api.ts
@@ -12,6 +12,7 @@ import {
 	ExerciseWeightInput,
 	ExerciseWeightResponse,
 	NullableCycleResponse,
+	NullablePreviousMaxesResponse,
 	ProgressionResponse,
 	RpeNumber,
 	SetResponse,
@@ -110,6 +111,12 @@ export class CyclesGroup extends HttpApiGroup.make("cycles")
 				NotFoundError.pipe(HttpApiSchema.status(404)),
 				InternalError.pipe(HttpApiSchema.status(500)),
 			],
+		}),
+	)
+	.add(
+		HttpApiEndpoint.get("previousMaxes", "/api/v1/cycles/previous-maxes", {
+			success: NullablePreviousMaxesResponse,
+			error: [InternalError.pipe(HttpApiSchema.status(500))],
 		}),
 	) {}
 

--- a/packages/shared/src/schema/api.ts
+++ b/packages/shared/src/schema/api.ts
@@ -5,7 +5,7 @@ import { ExercisePreference } from "./entities/exercise-preference.js";
 import { ExerciseWeight } from "./entities/exercise-weight.js";
 import { Workout } from "./entities/workout.js";
 import { WorkoutSet } from "./entities/workout-set.js";
-import { MainLift } from "./lifts.js";
+import { MainLift, Unit } from "./lifts.js";
 import { PrescribedSet, RpeSet } from "./workout.js";
 
 // --- RPE validation ---
@@ -138,3 +138,17 @@ export const ExerciseWeightInput = Schema.Struct({
 	unit: Schema.String,
 	rpe: Schema.NullOr(RpeNumber),
 });
+
+// --- Previous Maxes ---
+
+export const PreviousMaxesResponse = Schema.Struct({
+	squat: Schema.NullOr(Schema.Number),
+	bench: Schema.NullOr(Schema.Number),
+	deadlift: Schema.NullOr(Schema.Number),
+	ohp: Schema.NullOr(Schema.Number),
+	unit: Unit,
+});
+
+export const NullablePreviousMaxesResponse = Schema.NullOr(
+	PreviousMaxesResponse,
+);

--- a/packages/shared/src/schema/api.ts
+++ b/packages/shared/src/schema/api.ts
@@ -5,7 +5,7 @@ import { ExercisePreference } from "./entities/exercise-preference.js";
 import { ExerciseWeight } from "./entities/exercise-weight.js";
 import { Workout } from "./entities/workout.js";
 import { WorkoutSet } from "./entities/workout-set.js";
-import { MainLift, Unit } from "./lifts.js";
+import { MainLift, UserLifts } from "./lifts.js";
 import { PrescribedSet, RpeSet } from "./workout.js";
 
 // --- RPE validation ---
@@ -141,13 +141,7 @@ export const ExerciseWeightInput = Schema.Struct({
 
 // --- Previous Maxes ---
 
-export const PreviousMaxesResponse = Schema.Struct({
-	squat: Schema.NullOr(Schema.Number),
-	bench: Schema.NullOr(Schema.Number),
-	deadlift: Schema.NullOr(Schema.Number),
-	ohp: Schema.NullOr(Schema.Number),
-	unit: Unit,
-});
+export const PreviousMaxesResponse = UserLifts;
 
 export const NullablePreviousMaxesResponse = Schema.NullOr(
 	PreviousMaxesResponse,


### PR DESCRIPTION
## Summary

Closes #119

When starting a new cycle, maxes now auto-populate from the most recently completed cycle instead of requiring manual re-entry. User-set values always take priority.

- New `GET /api/v1/cycles/previous-maxes` endpoint returns latest completed cycle's maxes
- `POST /api/v1/cycles/next` handler falls back to previous maxes for any null lifts
- SetupIsland pre-fills inputs from previous cycle for returning users
- Uses most recent completed cycle (not historical max) for safety

## Test Plan

- [ ] New query `findLatestCompletedCycleMaxes` selects from completed cycles ordered by completedAt DESC
- [ ] `previousMaxes` handler returns null for first-time users (no completed cycles)
- [ ] `previousMaxes` handler returns decoded maxes with validated unit for returning users
- [ ] `next` handler uses payload values when provided (existing behavior preserved)
- [ ] `next` handler falls back to previous cycle maxes when payload values are null
- [ ] SetupIsland pre-fills inputs from previous maxes for returning users
- [ ] SetupIsland shows empty inputs for first-time users (no previous cycles)
- [ ] SetupIsland shows "Pre-filled from your last cycle" indicator when pre-filled
- [ ] User can override any pre-filled value
- [ ] All 165 unit tests pass
- [ ] Typecheck passes with zero errors

---
*Generated by `/execute` from plan: `~/c0de/plans/powercycle/auto-populate-maxes.md`*